### PR TITLE
feat: Enhance teacher group management UI and functionality

### DIFF
--- a/frontend/src/components/ConfirmationModal.jsx
+++ b/frontend/src/components/ConfirmationModal.jsx
@@ -6,10 +6,11 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
+  TextField, // <-- Import TextField
 } from '@mui/material';
 
 // Componente de Modal de Confirmación reutilizable
-// Añadimos props para texto de botones personalizable
+// Añadimos props para texto de botones personalizable y campo de entrada opcional
 const ConfirmationModal = React.memo(({
   open,
   onClose,
@@ -17,8 +18,37 @@ const ConfirmationModal = React.memo(({
   title,
   message,
   cancelText = 'No', // <-- Texto por defecto "No"
-  confirmText = 'Sí'  // <-- Texto por defecto "Sí"
+  confirmText = 'Sí',  // <-- Texto por defecto "Sí"
+  showInput = false, // <-- Prop para mostrar el campo de entrada
+  inputLabel = '', // <-- Etiqueta para el campo de entrada
+  inputValue = '', // <-- Valor del campo de entrada (controlado desde fuera)
+  onInputChange, // <-- Manejador para cambios en el campo de entrada
 }) => {
+  // Estado interno para el valor del input si no se quiere controlar totalmente desde fuera
+  // Sin embargo, para el caso de uso de "tipear nombre", es mejor que sea controlado.
+  // const [internalInputValue, setInternalInputValue] = React.useState('');
+
+  // React.useEffect(() => {
+  //   if (open) { // Reset input when modal opens if not controlled
+  //     setInternalInputValue('');
+  //   }
+  // }, [open]);
+
+  // const handleInputChange = (event) => {
+  //   setInternalInputValue(event.target.value);
+  //   if (onInputChange) {
+  //     onInputChange(event); // Llama al manejador externo si existe
+  //   }
+  // };
+
+  const handleConfirm = () => {
+    if (showInput) {
+      onConfirm(inputValue); // Pasa el valor del input a onConfirm
+    } else {
+      onConfirm(); // Comportamiento original
+    }
+  };
+
   return (
     <Dialog
       open={open}
@@ -30,15 +60,29 @@ const ConfirmationModal = React.memo(({
         {title}
       </DialogTitle>
       <DialogContent>
-        <DialogContentText id="confirmation-dialog-description">
+        <DialogContentText id="confirmation-dialog-description" sx={{ mb: showInput ? 2 : 0 }}>
           {message}
         </DialogContentText>
+        {showInput && (
+          <TextField
+            autoFocus // Enfocar el campo de texto si se muestra
+            margin="dense"
+            id="confirmation-input"
+            label={inputLabel}
+            type="text"
+            fullWidth
+            variant="standard"
+            value={inputValue}
+            onChange={onInputChange} // Usa el manejador de cambio de prop
+            sx={{ mt: 1 }}
+          />
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} color="secondary">
           {cancelText}
         </Button>
-        <Button onClick={onConfirm} color="primary" autoFocus>
+        <Button onClick={handleConfirm} color="primary"> {/* Usar handleConfirm */}
           {confirmText}
         </Button>
       </DialogActions>


### PR DESCRIPTION
Implements several improvements to the teacher group management page:

- Integrates a confirmation modal for approving and rejecting student join requests, improving clarity and reducing accidental actions.
- Implements a "Remove" student feature, allowing teachers to remove previously approved students from a group. This action requires the teacher to type the student's full name in a confirmation dialog to prevent errors.
- Enhances the student list by making each student's name a direct link to their user profile page, allowing for easier review of student information.

These changes provide teachers with more robust tools for managing their groups and student memberships.