### PR TITLE
feat: Implement Admin Group Management functionality

### DIFF
--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -9,7 +9,10 @@ const {
   approveDocente,
   getAllUsers,
   getUserById,
-  updateUserStatus
+  updateUserStatus,
+  getAllGroupsForAdmin,
+  archiveGroupAsAdmin,
+  restoreGroupAsAdmin
 } = require('../controllers/adminController');
 
 // Aplica protección y autorización a todas las rutas de este router
@@ -165,5 +168,81 @@ router.get('/users/:userId', getUserById);
  *         description: No autorizado
  */
 router.put('/users/:userId/status', updateUserStatus);
+
+/**
+ * @swagger
+ * /api/admin/groups:
+ *   get:
+ *     summary: Obtener la lista completa de todos los grupos
+ *     tags: [Administración]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de grupos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Group'
+ *       401:
+ *         description: No autorizado
+ */
+router.get('/groups', getAllGroupsForAdmin);
+
+/**
+ * @swagger
+ * /api/admin/groups/{groupId}/archive:
+ *   put:
+ *     summary: Archivar un grupo (solo Admin)
+ *     tags: [Administración]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: groupId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID del grupo a archivar
+ *     responses:
+ *       200:
+ *         description: Grupo archivado correctamente
+ *       404:
+ *         description: Grupo no encontrado
+ *       400:
+ *         description: ID de grupo inválido
+ *       401:
+ *         description: No autorizado
+ */
+router.put('/groups/:groupId/archive', archiveGroupAsAdmin);
+
+/**
+ * @swagger
+ * /api/admin/groups/{groupId}/restore:
+ *   put:
+ *     summary: Restaurar un grupo archivado (solo Admin)
+ *     tags: [Administración]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: groupId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: ID del grupo a restaurar
+ *     responses:
+ *       200:
+ *         description: Grupo restaurado correctamente
+ *       404:
+ *         description: Grupo no encontrado
+ *       400:
+ *         description: ID de grupo inválido
+ *       401:
+ *         description: No autorizado
+ */
+router.put('/groups/:groupId/restore', restoreGroupAsAdmin);
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,7 @@ import TeacherManageGroupPage from './pages/TeacherManageGroupPage';
 import TeacherContentBankPage from './pages/TeacherContentBankPage';
 
 import AdminUserManagementPage from './pages/AdminUserManagementPage';
+import AdminGroupManagementPage from './pages/AdminGroupManagementPage'; // Import the new page
 
 import TeacherLearningPathsPage from './pages/TeacherLearningPathsPage';
 import ManageLearningPathPage from './pages/ManageLearningPathPage';
@@ -152,6 +153,10 @@ function App() {
                   <Route
                     path="/admin/user-management"
                     element={<ProtectedRoute element={<AdminUserManagementPage />} allowedRoles={['Administrador']} />}
+                  />
+                  <Route
+                    path="/admin/groups" // Add new route for Admin Group Management
+                    element={<ProtectedRoute element={<AdminGroupManagementPage />} allowedRoles={['Administrador']} />}
                   />
                   <Route
                     path="/content-bank"

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -49,7 +49,7 @@ const Sidebar = React.memo(({ width = drawerWidth, open = true, onClose }) => {
     Administrador: [
       { text: 'Stats', icon: <DashboardIcon />, path: '/dashboard-admin' },
       { text: 'Gestión de Usuarios', icon: <PersonIcon />, path: '/admin/user-management' },
-      { text: 'Gestión de Grupos', icon: <GroupsIcon />, path: '/gestion-grupos-admin' },
+      { text: 'Gestión de Grupos', icon: <GroupsIcon />, path: '/admin/groups' }, // Updated path
       { text: 'Configuración del Sistema', icon: <SettingsIcon />, path: '/admin/config' },
     ],
     Common: [

--- a/frontend/src/pages/AdminGroupManagementPage.jsx
+++ b/frontend/src/pages/AdminGroupManagementPage.jsx
@@ -1,0 +1,269 @@
+// src/pages/AdminGroupManagementPage.jsx
+
+import React, { useEffect, useState, useRef } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+import {
+  Container,
+  Typography,
+  Box,
+  CircularProgress,
+  Alert,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Chip,
+  Link,
+  Button,
+  Stack
+} from '@mui/material';
+import { useAuth, axiosInstance } from '../contexts/AuthContext';
+import { toast } from 'react-toastify';
+
+// Import reusable components
+import PageHeader from '../components/PageHeader';
+import EmptyState from '../components/EmptyState';
+import GroupIcon from '@mui/icons-material/Group'; // Icon for groups
+import ConfirmationModal from '../components/ConfirmationModal'; // Import ConfirmationModal
+
+function AdminGroupManagementPage() {
+    const { user, isAuthenticated, isAuthInitialized } = useAuth();
+
+    const [groups, setGroups] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const hasShownListSuccessToast = useRef(false);
+
+    // State for modal and actions
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [modalAction, setModalAction] = useState(() => () => {});
+    const [modalMessage, setModalMessage] = useState('');
+    const [currentGroupId, setCurrentGroupId] = useState(null);
+    const [actionLoading, setActionLoading] = useState({});
+
+
+    useEffect(() => {
+        if (isAuthInitialized) {
+            const fetchGroups = async () => {
+                if (!isAuthenticated || user?.tipo_usuario !== 'Administrador') {
+                    setIsLoading(false);
+                    setError('No tienes permiso para ver esta página.');
+                    toast.error('Acceso no autorizado.');
+                    return;
+                }
+
+                setIsLoading(true);
+                setError(null);
+                hasShownListSuccessToast.current = false; // Reset toast flag on new fetch
+
+                try {
+                    const response = await axiosInstance.get('/api/admin/groups');
+                    setGroups(response.data.data);
+
+                    if (!hasShownListSuccessToast.current) {
+                        if (response.data.data.length > 0) {
+                            toast.success('Lista de grupos cargada exitosamente.');
+                        } else {
+                            toast.info('No hay grupos registrados en el sistema.');
+                        }
+                        hasShownListSuccessToast.current = true;
+                    }
+                } catch (err) {
+                    console.error('Error al obtener lista de grupos:', err.response ? err.response.data : err.message);
+                    const errorMessage = err.response?.data?.message || 'Error al cargar la lista de grupos.';
+                    setError(errorMessage);
+                    toast.error(errorMessage);
+                    hasShownListSuccessToast.current = false; // Ensure toast can be shown again if fetch is retried after error
+                } finally {
+                    setIsLoading(false);
+                }
+            };
+            fetchGroups();
+        }
+    }, [isAuthenticated, user, isAuthInitialized]);
+
+    // --- Modal Helper Function ---
+    const openConfirmationModal = (groupId, actionType) => {
+        setCurrentGroupId(groupId);
+        const groupName = groups.find(g => g._id === groupId)?.nombre_grupo || 'este grupo';
+        if (actionType === 'archive') {
+            setModalMessage(`¿Estás seguro que deseas archivar el grupo "${groupName}"?`);
+            setModalAction(() => () => handleArchiveGroup(groupId));
+        } else if (actionType === 'restore') {
+            setModalMessage(`¿Estás seguro que deseas restaurar el grupo "${groupName}"?`);
+            setModalAction(() => () => handleRestoreGroup(groupId));
+        }
+        setIsModalOpen(true);
+    };
+
+    // --- Handler for Archiving Group ---
+    const handleArchiveGroup = async (groupId) => {
+        if (!isAuthenticated || user?.tipo_usuario !== 'Administrador') {
+            toast.error('No tienes permiso para realizar esta acción.');
+            return;
+        }
+        setActionLoading(prev => ({ ...prev, [groupId]: true }));
+        try {
+            const response = await axiosInstance.put(`/api/admin/groups/${groupId}/archive`);
+            const updatedGroup = response.data.data;
+            setGroups(prevGroups =>
+                prevGroups.map(g => (g._id === updatedGroup._id ? updatedGroup : g))
+            );
+            toast.success(response.data.message || 'Grupo archivado correctamente.');
+        } catch (err) {
+            console.error(`Error al archivar grupo ${groupId}:`, err.response ? err.response.data : err.message);
+            const errorMessage = err.response?.data?.message || 'Error al archivar el grupo.';
+            toast.error(errorMessage);
+        } finally {
+            setActionLoading(prev => ({ ...prev, [groupId]: false }));
+            setIsModalOpen(false);
+        }
+    };
+
+    // --- Handler for Restoring Group ---
+    const handleRestoreGroup = async (groupId) => {
+        if (!isAuthenticated || user?.tipo_usuario !== 'Administrador') {
+            toast.error('No tienes permiso para realizar esta acción.');
+            return;
+        }
+        setActionLoading(prev => ({ ...prev, [groupId]: true }));
+        try {
+            const response = await axiosInstance.put(`/api/admin/groups/${groupId}/restore`);
+            const updatedGroup = response.data.data;
+            setGroups(prevGroups =>
+                prevGroups.map(g => (g._id === updatedGroup._id ? updatedGroup : g))
+            );
+            toast.success(response.data.message || 'Grupo restaurado correctamente.');
+        } catch (err) {
+            console.error(`Error al restaurar grupo ${groupId}:`, err.response ? err.response.data : err.message);
+            const errorMessage = err.response?.data?.message || 'Error al restaurar el grupo.';
+            toast.error(errorMessage);
+        } finally {
+            setActionLoading(prev => ({ ...prev, [groupId]: false }));
+            setIsModalOpen(false);
+        }
+    };
+
+    if (!isAuthInitialized || isLoading) {
+        return (
+            <Container>
+                <Box sx={{ mt: 4, textAlign: 'center' }}>
+                    <CircularProgress />
+                    <Typography variant="body1" color="text.secondary" sx={{ mt: 2 }}>Cargando grupos...</Typography>
+                </Box>
+            </Container>
+        );
+    }
+
+    if (error && !isLoading) {
+        return (
+            <Container>
+                <PageHeader title="Gestión de Grupos" />
+                <Box sx={{ mt: 2, textAlign: 'center' }}>
+                    <Alert severity="error">{error}</Alert>
+                </Box>
+            </Container>
+        );
+    }
+
+    if (!isLoading && !error && groups.length === 0) {
+        return (
+            <Container>
+                <PageHeader title="Gestión de Grupos" />
+                <EmptyState
+                    message="No hay grupos registrados en el sistema en este momento."
+                    icon={GroupIcon}
+                />
+            </Container>
+        );
+    }
+
+    return (
+        <Container>
+            <Box sx={{ mt: 4 }}>
+                <PageHeader title="Gestión de Grupos" />
+
+                <TableContainer component={Paper} sx={{ mt: 3 }}>
+                    <Table>
+                        <TableHead>
+                            <TableRow>
+                                <TableCell>Nombre del Grupo</TableCell>
+                                <TableCell>Docente Creador</TableCell>
+                                <TableCell>Código de Acceso</TableCell>
+                                <TableCell align="center">Miembros (Aprobados)</TableCell>
+                                <TableCell align="center">Estado</TableCell>
+                                <TableCell align="center">Acciones</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {groups.map((group) => (
+                                <TableRow key={group._id}>
+                                    <TableCell>{group.nombre_grupo}</TableCell>
+                                    <TableCell>
+                                        {group.docente_id ? `${group.docente_id.nombre} ${group.docente_id.apellidos}` : 'Sistema/N/A'}
+                                    </TableCell>
+                                    <TableCell>{group.codigo_acceso}</TableCell>
+                                    <TableCell align="center">{group.approvedMemberCount}</TableCell>
+                                    <TableCell align="center">
+                                        <Chip
+                                            label={group.activo ? 'Activo' : 'Archivado'}
+                                            color={group.activo ? 'success' : 'default'}
+                                            size="small"
+                                        />
+                                    </TableCell>
+                                    <TableCell align="center">
+                                        <Stack direction="row" spacing={1} justifyContent="center">
+                                            {group.activo ? (
+                                                <Button
+                                                    variant="outlined"
+                                                    color="warning"
+                                                    size="small"
+                                                    onClick={() => openConfirmationModal(group._id, 'archive')}
+                                                    disabled={actionLoading[group._id]}
+                                                    startIcon={actionLoading[group._id] ? <CircularProgress size={16} color="inherit" /> : null}
+                                                >
+                                                    {actionLoading[group._id] ? 'Archivando...' : 'Archivar'}
+                                                </Button>
+                                            ) : (
+                                                <Button
+                                                    variant="outlined"
+                                                    color="success"
+                                                    size="small"
+                                                    onClick={() => openConfirmationModal(group._id, 'restore')}
+                                                    disabled={actionLoading[group._id]}
+                                                    startIcon={actionLoading[group._id] ? <CircularProgress size={16} color="inherit" /> : null}
+                                                >
+                                                    {actionLoading[group._id] ? 'Restaurando...' : 'Restaurar'}
+                                                </Button>
+                                            )}
+                                        </Stack>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+
+                <ConfirmationModal
+                    open={isModalOpen}
+                    onClose={() => setIsModalOpen(false)}
+                    onConfirm={() => {
+                        if (modalAction) {
+                            modalAction();
+                        }
+                        // setIsModalOpen(false); // Action handlers will close it
+                    }}
+                    title="Confirmar Acción"
+                    message={modalMessage}
+                    confirmText="Sí, Confirmar"
+                    cancelText="Cancelar"
+                />
+            </Box>
+        </Container>
+    );
+}
+
+export default AdminGroupManagementPage;


### PR DESCRIPTION
Adds a new feature allowing Administrators to view and manage all groups in the system.

Key changes:

Backend:
- Added new GET endpoint `/api/admin/groups` to fetch all groups, populating teacher details and active member counts. Authorized for Admins.
- Added new PUT endpoint `/api/admin/groups/:groupId/archive` for Admins to archive any group.
- Added new PUT endpoint `/api/admin/groups/:groupId/restore` for Admins to restore any group.
- Included Swagger documentation for all new admin group endpoints.

Frontend:
- Created `AdminGroupManagementPage.jsx` under `frontend/src/pages/`.
  - This page displays a table of all groups with details: Nombre del Grupo, Docente Creador, Código de Acceso, Miembros (Aprobados), and Estado.
  - Implemented functionality for Admins to archive and restore groups directly from this page, including confirmation modals.
  - All UI text is in Spanish.
- Added "Gestión de Grupos" to the sidebar navigation for Admin users, linking to `/admin/groups`.
- Set up the necessary routing in `App.jsx` for the new admin page, protected for the 'Administrador' role.

All new UI elements and messages are in Spanish as per requirements.