### PR TITLE
feat: Allow teachers to manually set module/theme progress for students

### DIFF
--- a/backend/src/routes/progressRoutes.js
+++ b/backend/src/routes/progressRoutes.js
@@ -8,7 +8,9 @@ const {
     updateThemeProgress,
     getStudentProgressForPath,
     getAllStudentProgressForPathForDocente,
-    getSpecificStudentProgressForPathForDocente
+    getSpecificStudentProgressForPathForDocente,
+    setModuleStatusByTeacher, // Import new function
+    setThemeStatusByTeacher   // Import new function
   } = require('../controllers/progressController');
 
 router.use(protect);
@@ -151,5 +153,102 @@ router.get('/group/:groupId/path/:learningPathId/docente', authorize('Docente'),
  *         description: Estudiante o ruta no encontrada
  */
 router.get('/student/:studentId/path/:learningPathId/docente', authorize('Docente'), getSpecificStudentProgressForPathForDocente);
+
+
+// --- New Routes for Teacher Bulk Updates ---
+
+/**
+ * @swagger
+ * /api/progress/teacher/set-module-status:
+ *   post:
+ *     summary: Establecer el estado de un módulo para todos los estudiantes de un grupo (Docente/Admin)
+ *     tags: [Progreso]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               moduleId:
+ *                 type: string
+ *                 description: ID del módulo a actualizar.
+ *               learningPathId:
+ *                 type: string
+ *                 description: ID de la ruta de aprendizaje a la que pertenece el módulo.
+ *               groupId:
+ *                 type: string
+ *                 description: ID del grupo para el cual se actualizará el progreso.
+ *               status:
+ *                 type: string
+ *                 enum: [No Iniciado, En Progreso, Completado]
+ *                 description: Nuevo estado para el módulo.
+ *     responses:
+ *       200:
+ *         description: Progreso del módulo actualizado para los estudiantes del grupo.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *       400:
+ *         description: Datos de entrada inválidos o error de validación.
+ *       401:
+ *         description: No autorizado (token faltante o inválido).
+ *       403:
+ *         description: Prohibido (usuario no tiene permisos o no es dueño del grupo/ruta).
+ *       404:
+ *         description: Recurso no encontrado (ruta, módulo, grupo).
+ *       500:
+ *         description: Error interno del servidor.
+ */
+router.post('/teacher/set-module-status', authorize(['Docente', 'Administrador']), setModuleStatusByTeacher);
+
+/**
+ * @swagger
+ * /api/progress/teacher/set-theme-status:
+ *   post:
+ *     summary: Establecer el estado de un tema para todos los estudiantes de un grupo (Docente/Admin)
+ *     tags: [Progreso]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               themeId:
+ *                 type: string
+ *                 description: ID del tema a actualizar.
+ *               learningPathId:
+ *                 type: string
+ *                 description: ID de la ruta de aprendizaje a la que pertenece el tema.
+ *               groupId:
+ *                 type: string
+ *                 description: ID del grupo para el cual se actualizará el progreso.
+ *               status:
+ *                 type: string
+ *                 enum: [No Iniciado, Visto, Completado]
+ *                 description: Nuevo estado para el tema.
+ *     responses:
+ *       200:
+ *         description: Progreso del tema actualizado para los estudiantes del grupo.
+ *       400:
+ *         description: Datos de entrada inválidos.
+ *       403:
+ *         description: Prohibido.
+ *       404:
+ *         description: Recurso no encontrado.
+ *       500:
+ *         description: Error interno del servidor.
+ */
+router.post('/teacher/set-theme-status', authorize(['Docente', 'Administrador']), setThemeStatusByTeacher);
+
 
 module.exports = router;

--- a/frontend/src/pages/components/ModuleItem.jsx
+++ b/frontend/src/pages/components/ModuleItem.jsx
@@ -11,12 +11,14 @@ import {
   Button,
   Stack,
   List,
-  Divider
+  Divider,
+  Tooltip // Added Tooltip
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddCircleOutlinedIcon from '@mui/icons-material/AddCircleOutlined';
+import RuleIcon from '@mui/icons-material/Rule'; // Added RuleIcon
 import ThemeItem from './ThemeItem'; // Will be created next
 
 const ModuleItem = React.memo(({
@@ -27,6 +29,8 @@ const ModuleItem = React.memo(({
   onEditModule,
   onDeleteModule,
   onCreateTheme,
+  onSetModuleStatus, 
+  onSetThemeStatus, // New prop for ThemeItem
   // Props needed for ThemeItem that are passed down
   expandedTheme,
   handleThemeAccordionChange,
@@ -52,6 +56,21 @@ const ModuleItem = React.memo(({
             <Typography variant="h6" sx={{ flexGrow: 1 }}>
               {`Módulo ${module.orden || moduleIndex + 1}: ${module.nombre}`}
             </Typography>
+            <Tooltip title="Establecer Progreso del Módulo">
+              <span> {/* Span needed for Tooltip when button is disabled */}
+                <IconButton
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation(); // Prevent Accordion toggle
+                    onSetModuleStatus(module);
+                  }}
+                  disabled={isAnyOperationInProgress}
+                  sx={{ mr: 1 }} // Added margin for spacing
+                >
+                  <RuleIcon fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
             <IconButton
               size="small"
               onClick={(e) => {
@@ -107,6 +126,7 @@ const ModuleItem = React.memo(({
                   onEditTheme={onEditTheme}
                   onDeleteTheme={onDeleteTheme}
                   onAddContentAssignment={onAddContentAssignment}
+                  onSetThemeStatus={(theme) => onSetThemeStatus(theme, module)} // Pass module context
                   onEditAssignment={onEditAssignment}
                   onDeleteAssignment={onDeleteAssignment}
                   onStatusChange={onStatusChange}

--- a/frontend/src/pages/components/SetModuleStatusModal.jsx
+++ b/frontend/src/pages/components/SetModuleStatusModal.jsx
@@ -1,0 +1,127 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button,
+  FormControl, InputLabel, Select, MenuItem, CircularProgress, Alert, Box
+} from '@mui/material';
+
+const SetModuleStatusModal = ({ open, onClose, moduleInfo, onConfirmSetStatus }) => {
+  const [selectedStatus, setSelectedStatus] = useState('No Iniciado'); // Default to 'No Iniciado'
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Reset status when modal opens
+  useEffect(() => {
+    if (open) {
+      setSelectedStatus('No Iniciado'); // Reset to 'No Iniciado' on open
+      setError(null); // Clear previous errors
+    }
+  }, [open]);
+  
+  // Reset status if moduleInfo changes while modal is open
+  useEffect(() => {
+    setSelectedStatus('No Iniciado'); // Reset to 'No Iniciado' if moduleInfo changes
+    setError(null);
+  }, [moduleInfo]);
+
+
+  const handleSubmit = async () => {
+    if (!selectedStatus) {
+      setError("Por favor, selecciona un estado.");
+      return;
+    }
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await onConfirmSetStatus(selectedStatus);
+      // onClose will be called by parent on success if onConfirmSetStatus resolves
+      // setSelectedStatus(''); // Resetting in parent's onClose or here
+    } catch (err) {
+      setError(err.message || 'Error al confirmar el estado. Inténtalo de nuevo.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = (event, reason) => {
+    if (isSubmitting && (reason === 'backdropClick' || reason === 'escapeKeyDown')) {
+      // Prevent closing while submitting
+      return;
+    }
+    onClose();
+    // setSelectedStatus(''); // Resetting status on any close action
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} aria-labelledby="set-module-status-dialog-title" fullWidth maxWidth="sm">
+      <DialogTitle id="set-module-status-dialog-title">
+        Establecer Progreso para Módulo: {moduleInfo?.moduleName || 'Desconocido'}
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ mb: 2 }}>
+          Selecciona el estado de progreso para aplicar a todos los estudiantes en el grupo 
+          "{moduleInfo?.groupName || 'N/A'}" para este módulo.
+        </DialogContentText>
+        
+        <FormControl fullWidth error={!!error && !selectedStatus} sx={{mt:1}}>
+          <InputLabel id="module-status-select-label">Estado de Progreso</InputLabel>
+          <Select
+            labelId="module-status-select-label"
+            value={selectedStatus}
+            label="Estado de Progreso"
+            onChange={(e) => {
+                setSelectedStatus(e.target.value);
+                if (error && e.target.value) setError(null); // Clear error once a selection is made
+            }}
+            disabled={isSubmitting}
+          >
+            <MenuItem value=""><em>Selecciona un estado</em></MenuItem>
+            <MenuItem value="No Iniciado">No Iniciado</MenuItem>
+            <MenuItem value="En Progreso">En Progreso</MenuItem>
+            <MenuItem value="Completado">Completado</MenuItem>
+          </Select>
+        </FormControl>
+
+        <Alert severity="warning" sx={{ mt: 2 }}>
+          Nota: Esta acción modificará el progreso para todos los estudiantes del grupo asociados a esta ruta de aprendizaje.
+        </Alert>
+
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ p: '16px 24px' }}>
+        <Button onClick={handleClose} disabled={isSubmitting}>
+          Cancelar
+        </Button>
+        <Button 
+          onClick={handleSubmit} 
+          variant="contained" 
+          color="primary" 
+          disabled={isSubmitting || !selectedStatus}
+          startIcon={isSubmitting ? <CircularProgress size="1rem" color="inherit" /> : null}
+        >
+          {isSubmitting ? 'Confirmando...' : 'Confirmar'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+SetModuleStatusModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  moduleInfo: PropTypes.shape({
+    moduleId: PropTypes.string,
+    moduleName: PropTypes.string,
+    learningPathId: PropTypes.string,
+    groupId: PropTypes.string,
+    groupName: PropTypes.string,
+  }),
+  onConfirmSetStatus: PropTypes.func.isRequired,
+};
+
+export default SetModuleStatusModal;

--- a/frontend/src/pages/components/SetThemeStatusModal.jsx
+++ b/frontend/src/pages/components/SetThemeStatusModal.jsx
@@ -1,0 +1,124 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button,
+  FormControl, InputLabel, Select, MenuItem, CircularProgress, Alert
+} from '@mui/material';
+
+const SetThemeStatusModal = ({ open, onClose, themeInfo, onConfirmSetStatus }) => {
+  const [selectedStatus, setSelectedStatus] = useState('No Iniciado'); // Default to 'No Iniciado'
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (open) {
+      setSelectedStatus('No Iniciado'); // Reset to 'No Iniciado' on open
+      setError(null); // Clear previous errors
+    }
+  }, [open]);
+  
+  // Reset status if themeInfo changes while modal is open
+  useEffect(() => {
+    setSelectedStatus('No Iniciado'); // Reset to 'No Iniciado' if themeInfo changes
+    setError(null);
+  }, [themeInfo]);
+
+  const handleSubmit = async () => {
+    if (!selectedStatus) {
+      setError("Por favor, selecciona un estado.");
+      return;
+    }
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await onConfirmSetStatus(selectedStatus);
+      // Parent will call onClose on successful promise resolution
+    } catch (err) {
+      setError(err.message || 'Error al confirmar el estado. Inténtalo de nuevo.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = (event, reason) => {
+    if (isSubmitting && (reason === 'backdropClick' || reason === 'escapeKeyDown')) {
+      // Prevent closing while submitting
+      return;
+    }
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} aria-labelledby="set-theme-status-dialog-title" fullWidth maxWidth="sm">
+      <DialogTitle id="set-theme-status-dialog-title">
+        Establecer Progreso para Tema: {themeInfo?.themeName || 'Desconocido'}
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText sx={{ mb: 2 }}>
+          Selecciona el estado de progreso para aplicar a todos los estudiantes en el grupo 
+          "{themeInfo?.groupName || 'N/A'}" para este tema.
+        </DialogContentText>
+        
+        <FormControl fullWidth error={!!error && !selectedStatus} sx={{mt:1}}>
+          <InputLabel id="theme-status-select-label">Estado de Progreso</InputLabel>
+          <Select
+            labelId="theme-status-select-label"
+            value={selectedStatus}
+            label="Estado de Progreso"
+            onChange={(e) => {
+                setSelectedStatus(e.target.value);
+                if (error && e.target.value) setError(null); // Clear error once a selection is made
+            }}
+            disabled={isSubmitting}
+          >
+            <MenuItem value=""><em>Selecciona un estado</em></MenuItem>
+            <MenuItem value="No Iniciado">No Iniciado</MenuItem>
+            <MenuItem value="Visto">Visto</MenuItem>
+            <MenuItem value="Completado">Completado</MenuItem>
+          </Select>
+        </FormControl>
+
+        <Alert severity="warning" sx={{ mt: 2 }}>
+          Nota: Esta acción modificará el progreso para todos los estudiantes del grupo asociados a esta ruta de aprendizaje en este tema.
+        </Alert>
+
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ p: '16px 24px' }}>
+        <Button onClick={handleClose} disabled={isSubmitting}>
+          Cancelar
+        </Button>
+        <Button 
+          onClick={handleSubmit} 
+          variant="contained" 
+          color="primary" 
+          disabled={isSubmitting || !selectedStatus}
+          startIcon={isSubmitting ? <CircularProgress size="1rem" color="inherit" /> : null}
+        >
+          {isSubmitting ? 'Confirmando...' : 'Confirmar'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+SetThemeStatusModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  themeInfo: PropTypes.shape({
+    themeId: PropTypes.string,
+    themeName: PropTypes.string,
+    moduleId: PropTypes.string,
+    learningPathId: PropTypes.string,
+    groupId: PropTypes.string,
+    groupName: PropTypes.string,
+  }),
+  onConfirmSetStatus: PropTypes.func.isRequired,
+};
+
+export default SetThemeStatusModal;

--- a/frontend/src/pages/components/ThemeItem.jsx
+++ b/frontend/src/pages/components/ThemeItem.jsx
@@ -11,12 +11,14 @@ import {
   Button,
   Stack,
   List,
-  Divider
+  Divider,
+  Tooltip // Added Tooltip
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddCircleOutlinedIcon from '@mui/icons-material/AddCircleOutlined';
+import RuleIcon from '@mui/icons-material/Rule'; // Added RuleIcon
 import AssignmentItem from './AssignmentItem'; // Will be created next
 
 const ThemeItem = React.memo(({
@@ -27,6 +29,7 @@ const ThemeItem = React.memo(({
   onEditTheme,
   onDeleteTheme,
   onAddContentAssignment,
+  onSetThemeStatus, // New prop
   // Props needed for AssignmentItem that are passed down
   onEditAssignment,
   onDeleteAssignment,
@@ -47,6 +50,21 @@ const ThemeItem = React.memo(({
             <Typography variant="subtitle1" sx={{ flexGrow: 1 }}>
               {`Tema ${theme.orden || themeIndex + 1}: ${theme.nombre}`}
             </Typography>
+            <Tooltip title="Establecer Progreso del Tema">
+              <span> {/* Span for Tooltip when button is disabled */}
+                <IconButton
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation(); // Prevent Accordion toggle
+                    onSetThemeStatus(theme); // Call the new handler
+                  }}
+                  disabled={isAnyOperationInProgress}
+                  sx={{ mr: 1 }} // Added margin for spacing
+                >
+                  <RuleIcon fontSize="small"/>
+                </IconButton>
+              </span>
+            </Tooltip>
             <IconButton
               size="small"
               onClick={(e) => {


### PR DESCRIPTION
I've implemented functionality for teachers to set the progress status ('No Iniciado', 'En Progreso', 'Completado', or 'Visto' for themes) for specific modules or themes, applying this status to all students in the associated group.

Backend:
- I added new API endpoints:
    - `POST /api/progress/teacher/set-module-status`
    - `POST /api/progress/teacher/set-theme-status`
- I implemented controller logic in `progressController.js` to handle these requests, including:
    - Authorization to ensure only owning teachers/admins can make changes.
    - Bulk updates to `ProgressModel` documents for all approved students in the group.
    - Logic to cascade changes (e.g., setting a module 'Completado' also marks its themes 'Completado').
- I enhanced the `updateDependentStatuses` helper function to correctly recalculate statuses after teacher overrides, respecting direct 'En Progreso' settings for modules.

Frontend (`ManageLearningPathPage.jsx` and sub-components):
- I added "Set Status" icon buttons next to each module and theme in the learning path structure view.
- I created `SetModuleStatusModal.jsx`: This allows teachers to select a status for a module and confirm.
- I created `SetThemeStatusModal.jsx`: This allows teachers to select a status for a theme and confirm.
- The modals display relevant module/theme and group information and include warnings about the scope of the action.
- API calls are made from `ManageLearningPathPage.jsx` with toast notifications for success/failure.
- The modals have internal state for selection, submission, and error display. The default status selection is 'No Iniciado'.

This feature provides teachers with greater control over managing and initializing student progress within their learning paths.