### PR TITLE
feat: Implement Time Limit for Quiz and Questionnaire Activities

### DIFF
--- a/backend/src/models/SubmissionModel.js
+++ b/backend/src/models/SubmissionModel.js
@@ -50,10 +50,12 @@ const submissionSchema = new mongoose.Schema({
         // Este campo se llenará en el controlador cuando el estudiante envíe la entrega
         index: true
     },
+    attempt_start_time: { type: Date },
+    is_timed_auto_submit: { type: Boolean, default: false },
     estado_envio: { // Estado actual de la entrega
         type: String,
         required: [true, 'El estado de la entrega es obligatorio'],
-        enum: ['Pendiente', 'Enviado', 'Calificado'], // Estados posibles: Pendiente de envío, Ya enviado, Calificado
+        enum: ['Pendiente', 'InProgress', 'Enviado', 'Calificado'], // Estados posibles: Pendiente de envío, Ya enviado, Calificado
         default: 'Pendiente', // Estado inicial antes de que el estudiante envíe
         index: true
     },


### PR DESCRIPTION
This commit introduces a time limit feature for Quiz and Questionnaire activities.

Backend Changes:
- Modified `SubmissionModel.js` to include `attempt_start_time`, `is_timed_auto_submit`, and an 'InProgress' state for `estado_envio`.
- Updated `activityController.js` (`getStudentActivityForAttempt`):
    - Creates or resumes an 'InProgress' submission when you start a timed activity.
    - Returns `tiempo_limite`, `submissionId`, and `attempt_start_time` to the frontend.
- Updated `activityController.js` (`submitStudentActivityAttempt`):
    - Handles submissions associated with an 'InProgress' `submissionId`.
    - Verifies against `tiempo_limite` and `attempt_start_time`.
    - Sets `is_timed_auto_submit` flag if the time limit is exceeded.
    - Updates the existing submission record.

Frontend Changes:
- Modified `StudentTakeActivityPage.jsx`:
    - Fetches timer-related data (`tiempo_limite`, `attempt_start_time`, `submissionId`).
    - Displays a countdown timer for timed activities.
    - Automatically submits your current answers when the timer expires.
    - Sends `submissionId` with the attempt data.
- Verified that `AddContentAssignmentModal.jsx` and `EditContentAssignmentModal.jsx` already support setting `tiempo_limite` for assignments.

The implementation allows teachers to set a time limit (in minutes) when assigning Quizzes or Questionnaires. When you start such an activity, a timer begins. If the timer expires before you submit, your current work is submitted automatically.